### PR TITLE
Fix compatibility with Minecraft 26.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Ultimate Foods</name>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -23,14 +23,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -40,7 +39,7 @@
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <minimizeJar>true</minimizeJar>
-                            <outputFile>C:\Users\7Dev\Desktop\1.21.9\plugins\${project.artifactId}-${project.version}.jar</outputFile>
+                            <outputFile>${project.basedir}/target/${project.artifactId}-${project.version}.jar</outputFile>
                             <relocations>
                                 <relocation>
                                     <pattern>com.google.gson</pattern>
@@ -130,8 +129,8 @@
     <dependencies>
         <dependency>
             <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>        
-            <version>1.21.9-R0.1-SNAPSHOT</version> 
+            <artifactId>paper-api</artifactId>
+            <version>26.1.2.build.63-stable</version>
             <scope>provided</scope>
         </dependency>
 
@@ -154,7 +153,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.0.0</version>
+            <version>5.4.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/net/juligame/ultimatefoods/classes/Recipe.java
+++ b/src/main/java/net/juligame/ultimatefoods/classes/Recipe.java
@@ -48,32 +48,16 @@ public class Recipe {
     }
 
     public static void removeRecipe(ItemStack itemStack){
-        ItemStack itemToRemove = null;
         if (itemStack == null || itemStack.getType().equals(Material.AIR))
             return;
 
-        List<org.bukkit.inventory.Recipe> recipes = UltimateFoods.instance.getServer().getRecipesFor(itemStack);
-
-        for (org.bukkit.inventory.Recipe recipe : recipes) {
-            if (recipe == null)
-                continue;
-
-            if(recipe.getResult().equals(itemStack)){
-                itemToRemove = recipe.getResult();
-                break;
+        Material targetMaterial = itemStack.getType();
+        Iterator<org.bukkit.inventory.Recipe> iterator = Bukkit.getServer().recipeIterator();
+        while (iterator.hasNext()) {
+            org.bukkit.inventory.Recipe recipe = iterator.next();
+            if (recipe != null && recipe.getResult().getType().equals(targetMaterial)) {
+                iterator.remove();
             }
-        }
-
-        if (itemToRemove != null) {
-            Iterator<org.bukkit.inventory.Recipe> iterator = Bukkit.getServer().recipeIterator();
-            while (iterator.hasNext()) {
-                org.bukkit.inventory.Recipe recipe = iterator.next();
-                if (recipe != null && recipe.getResult().equals(itemToRemove)) {
-                    iterator.remove();
-                }
-            }
-        } else {
-            Bukkit.getLogger().info("Item to remove not found");
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: UltimateFood
 version: '1.5.0'
 main: net.juligame.ultimatefoods.UltimateFoods
-api-version: '1.21'
+api-version: '26.1'
 authors: [ JuliGame, RoloGod ]
 description: The Ultimate Food plugin ;)
 commands:


### PR DESCRIPTION
## Summary

- **Recipe.removeRecipe()**: The old code compared full ItemStack objects (including custom display name, lore, and persistent data) against plain vanilla recipe results — they never matched, causing 30+ \"Item to remove not found\" log spam on every startup. Fixed by comparing `Material` type only, which is the correct intent.
- **pom.xml**: Updated Paper API dependency to `26.1.2.build.63-stable`, bumped Java source/target to 21 (required by Paper 26.1.2), upgraded `maven-shade-plugin` from 3.2.4 to 3.6.0 (3.2.4 cannot process Java 21 class files), updated ProtocolLib to `5.4.0-SNAPSHOT` (5.0.0 is no longer in any public repo), removed hardcoded Windows output path.
- **plugin.yml**: Updated `api-version` from `1.21` to `26.1` to match the new Minecraft versioning scheme.

## Test plan

- [x] Plugin loads without errors on Paper 26.1.2 build 63
- [x] No \"Item to remove not found\" errors on startup
- [x] Custom foods load and apply effects correctly
- [ ] Crafting recipes for custom foods work in-game (needs player testing)

Tested on macOS with Java 25.0.3 and Paper 26.1.2 build 63.